### PR TITLE
decode and interpolate terraform block

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,13 @@ type Terradude struct {
 }
 
 type Terraform struct {
-  Remain hcl.Body `hcl:",remain"`
+	Module Module   `hcl:"module,block"`
+}
+
+type Module struct {
+	Name   string   `hcl:"name,label"`
+	Source string   `hcl:"source,attr"`
+	Body   hcl.Body `hcl:",remain"`
 }
 
 type Dependency struct {

--- a/live/stage/aws/eu-west-1/default/services/a-single-server/terradude.hcl
+++ b/live/stage/aws/eu-west-1/default/services/a-single-server/terradude.hcl
@@ -6,8 +6,8 @@ terraform {
     source = "../../../../../../../modules/ec2/modules/single-server/"
 
     parameter = [""]
-    vpc_id = local.terradude.dependency.vpc.outputs.vpc_id
-    region = local.terradude.global.aws_region
+    vpc_id = "local.terradude.dependency.vpc.outputs.vpc_id"
+    region = global.aws_region
   }
 }
 

--- a/live/stage/aws/eu-west-1/vpc-1/single-server/terradude.hcl
+++ b/live/stage/aws/eu-west-1/vpc-1/single-server/terradude.hcl
@@ -23,7 +23,7 @@ terraform {
     instance_type = "t2.small"
     ami           = "ami-ebd02392"
 
-    subnet_idsubnet_ids = dependency.vpc.outputs.public_subnets
+    subnet_idsubnet_ids = "dependency.vpc.outputs.public_subnets"
 
     tags = {
       Terradude = "true"


### PR DESCRIPTION
- allow exatcly one module block in terraform block
- module block must have source and label

had to remove planned dependency interpolation as not implemented yet lets start with MVP without dependency support...

- needs adjustment of source path when relative

its a PoC implementation -> will be modularized later.. ;)